### PR TITLE
add: New option to select preferred local audio player binary

### DIFF
--- a/index.js
+++ b/index.js
@@ -510,14 +510,7 @@ module.exports = function(app) {
     app.debug("play")
     playing_sound = true
 
-    if ( plugin_props.alarmAudioPlayer === undefined ) {
-       if ( os.platform() == 'darwin' )
-         command = 'afplay'
-       else
-         command = 'omxplayer'
-    } else {
-       command = plugin_props.alarmAudioPlayer
-    }
+    command = plugin_props.alarmAudioPlayer
     app.debug("sound_player: " + command)
 
     sound_file = plugin_props.alarmAudioFile
@@ -588,7 +581,14 @@ module.exports = function(app) {
       defaultId = discovered.src
       description = `Found a ${discovered.productName} with src ${discovered.src}`
     }
-   
+
+
+    if ( os.platform() == 'darwin' )
+       defaultAudioPlayer = 'afplay'
+    else
+       defaultAudioPlayer = 'omxplayer'
+
+
     let schema = {
       title: "Fusion Stereo Control",
       type: "object",
@@ -640,9 +640,11 @@ module.exports = function(app) {
           default: 12
         },
         alarmAudioPlayer: {
+          title: "Audio Player",
+          description: "Select command line audio player",
           type: "string",
-          title: "Name of audio player (optional)",
-          default: "default"
+          default: defaultAudioPlayer,
+          "enum": ["afplay", "omxplayer", "mpg321"]
         }
       }
     }

--- a/index.js
+++ b/index.js
@@ -583,10 +583,9 @@ module.exports = function(app) {
     }
 
 
+    let defaultAudioPlayer = 'omxplayer'
     if ( os.platform() == 'darwin' )
        defaultAudioPlayer = 'afplay'
-    else
-       defaultAudioPlayer = 'omxplayer'
 
 
     let schema = {

--- a/index.js
+++ b/index.js
@@ -510,10 +510,15 @@ module.exports = function(app) {
     app.debug("play")
     playing_sound = true
 
-    if ( os.platform() == 'darwin' )
-      command = 'afplay'
-    else
-      command = 'omxplayer'
+    if ( plugin_props.alarmAudioPlayer === undefined ) {
+       if ( os.platform() == 'darwin' )
+         command = 'afplay'
+       else
+         command = 'omxplayer'
+    } else {
+       command = plugin_props.alarmAudioPlayer
+    }
+    app.debug("sound_player: " + command)
 
     sound_file = plugin_props.alarmAudioFile
     if ( sound_file.charAt(0) != '/' )
@@ -559,6 +564,7 @@ module.exports = function(app) {
         "alarmUnMute",
         "alarmSetVolume",
         "alarmVolume",
+        "alarmAudioPlayer",
       ]
     }
     if ( availableSources.length > 0 ) {
@@ -632,6 +638,11 @@ module.exports = function(app) {
           type: "number",
           title: "Alarm Volume (0-24)",
           default: 12
+        },
+        alarmAudioPlayer: {
+          type: "string",
+          title: "Name of audio player (optional)",
+          default: "default"
         }
       }
     }


### PR DESCRIPTION
For Linux the implementation set "omxplayer" as default player for mp3, which is not installed on headless raspbian buster.
Installing it via apt-get would trigger installation of a graphics stack (mesa-va-drivers mesa-vdpau-drivers omxplayer va-driver-all etc.).

To omit that, now the user can specify an alternative mp3 player (e.g. mpg321). Defaults are as before.